### PR TITLE
5814833 Modules stuck in crash backoff loop when updating and mount to a ReadWriteOnce PV

### DIFF
--- a/src/createoptions_extensions.md
+++ b/src/createoptions_extensions.md
@@ -59,6 +59,8 @@ A `volumes` section of config used to describe how a `ConfigMap` or any other vo
   }
 }
 ```
+Note, when a volume is specified as "ReadWriteOnce", there is an known issue that the module with the ReadWriteOnce volume mounted can be stuck at crash backoff loop state when updating through a new deployment. 
+To workaround, one has to delete the module and re-deploy with the new setting(s). 
 
 ## CPU, Memory and Device Resources
 


### PR DESCRIPTION
5814833 Modules in crash backoff loop seem to hang around and stay in
crash backoff loop, even if deployment is updated and that pod is no
longer supposed to be running.

This is to add/explain the workaround for public preview refresh. 